### PR TITLE
Use environment variables for an activated environment

### DIFF
--- a/environment_kernels/__init__.py
+++ b/environment_kernels/__init__.py
@@ -1,1 +1,2 @@
+from __future__ import absolute_import
 from .core import *


### PR DESCRIPTION
Use the xonsh functions form the last commit to get the environment variables
from an activated environment and pass that to the kernel command line.

This is up to now only tested on windows with conda environment variables. virtualenv is basically just modeled after the docs: I've no clue if that works at all...