### PR TITLE
Implement lazy loading of the activated environment variables

### DIFF
--- a/environment_kernels/activate_helper.py
+++ b/environment_kernels/activate_helper.py
@@ -35,6 +35,8 @@ ON_ANACONDA = any(s in sys.version for s in {'Anaconda', 'Continuum'})
 
 ON_POSIX = (os.name == 'posix')
 
+ENV_SPLIT_RE = re.compile('^([^=]+)=([^=]*|[^\n]*)$',flags=re.DOTALL|re.MULTILINE)
+
 def source_bash(args, stdin=None):
     """Simply bash-specific wrapper around source-foreign
 
@@ -479,8 +481,7 @@ def parse_env(s):
     if m is None:
         return {}
     g1 = m.group(1)
-    items = [line.split('=', 1) for line in g1.splitlines() if '=' in line]
-    env = dict(items)
+    env = dict(ENV_SPLIT_RE.findall(g1))
     return env
 
 

--- a/environment_kernels/activate_helper.py
+++ b/environment_kernels/activate_helper.py
@@ -19,6 +19,11 @@ import re
 import sys
 from itertools import chain
 
+try:
+    FileNotFoundError
+except NameError:
+    # py2
+    FileNotFoundError = IOError
 
 ON_DARWIN = platform.system() == 'Darwin'
 ON_LINUX = platform.system() == 'Linux'

--- a/environment_kernels/activate_helper.py
+++ b/environment_kernels/activate_helper.py
@@ -10,6 +10,33 @@ Copied from xonsh"""
 # - add source_bash and source_zsh
 # - Changed the default for "save" in all function definitions/parser to False to get exceptions
 
+# Original license:
+# Copyright 2015-2016, the xonsh developers. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+#    1. Redistributions of source code must retain the above copyright notice, this list of
+#       conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright notice, this list
+#       of conditions and the following disclaimer in the documentation and/or other materials
+#       provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE XONSH DEVELOPERS ``AS IS'' AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE XONSH DEVELOPERS OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# The views and conclusions contained in the software and documentation are those of the
+# authors and should not be interpreted as representing official policies, either expressed
+# or implied, of the stakeholders of the xonsh project or the employers of xonsh developers.
+
 import os
 import platform
 from argparse import ArgumentParser

--- a/environment_kernels/activate_helper.py
+++ b/environment_kernels/activate_helper.py
@@ -37,30 +37,17 @@ Copied from xonsh"""
 # authors and should not be interpreted as representing official policies, either expressed
 # or implied, of the stakeholders of the xonsh project or the employers of xonsh developers.
 
+from __future__ import absolute_import
+
 import os
-import platform
 from argparse import ArgumentParser
 import subprocess
 from tempfile import NamedTemporaryFile
 import re
-import sys
 from itertools import chain
 
-try:
-    FileNotFoundError
-except NameError:
-    # py2
-    FileNotFoundError = IOError
+from .utils import FileNotFoundError, ON_WINDOWS
 
-ON_DARWIN = platform.system() == 'Darwin'
-ON_LINUX = platform.system() == 'Linux'
-ON_WINDOWS = platform.system() == 'Windows'
-
-PYTHON_VERSION_INFO = sys.version_info[:3]
-ON_ANACONDA = any(s in sys.version for s in {'Anaconda', 'Continuum'})
-
-
-ON_POSIX = (os.name == 'posix')
 
 ENV_SPLIT_RE = re.compile('^([^=]+)=([^=]*|[^\n]*)$',flags=re.DOTALL|re.MULTILINE)
 
@@ -112,7 +99,7 @@ def locate_binary(name):
 
     directories = os.environ.get('PATH').split(os.path.pathsep)
 
-    # Windows users expect t obe able to execute files in the same directory without `./`
+    # Windows users expect to be able to execute files in the same directory without `./`
     if ON_WINDOWS:
         directories = [_get_cwd()] + directories
 

--- a/environment_kernels/core.py
+++ b/environment_kernels/core.py
@@ -10,7 +10,7 @@ from jupyter_client.kernelspec import (KernelSpecManager, KernelSpec,
                                        NoSuchKernel)
 from ipykernel.kernelspec import RESOURCES
 
-from .activate_helper import source_bash, source_zsh, source_cmd, ON_WINDOWS
+from .activate_helper import source_bash, source_zsh, source_cmd
 
 from traitlets import List, Unicode, Bool
 
@@ -23,11 +23,7 @@ try:
 except ImportError:
     HAVE_CONDA = False
 
-try:
-    FileNotFoundError
-except NameError:
-    # py2
-    FileNotFoundError = IOError
+from .utils import FileNotFoundError, ON_WINDOWS
 
 
 def _source_env_vars_from_command(args):

--- a/environment_kernels/lazyobj.py
+++ b/environment_kernels/lazyobj.py
@@ -1,0 +1,89 @@
+"""Lazy and self destructive container for speeding up module import."""
+# Copyright 2015-2016, the xonsh developers. All rights reserved.
+
+# Inspiration by https://github.com/xonsh/xonsh/blob/master/xonsh/lazyasd.py
+
+# Original license:
+# Copyright 2015-2016, the xonsh developers. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+#    1. Redistributions of source code must retain the above copyright notice, this list of
+#       conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright notice, this list
+#       of conditions and the following disclaimer in the documentation and/or other materials
+#       provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE XONSH DEVELOPERS ``AS IS'' AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE XONSH DEVELOPERS OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# The views and conclusions contained in the software and documentation are those of the
+# authors and should not be interpreted as representing official policies, either expressed
+# or implied, of the stakeholders of the xonsh project or the employers of xonsh developers.
+
+from __future__ import absolute_import
+from .utils import MutableMapping
+
+
+# can't use MutableMapping only, because downstream (json.dumps and traitlets) tests for dict
+# directly :-(
+class LazyProxyDict(MutableMapping, dict):
+
+    def __init__(self, load):
+        """Dictionary like object that lazily loads its values via the load function
+
+        Parameters
+        ----------
+        load : loader which returns the real dict.
+        """
+        self._lasdo = {
+            'loaded': False,
+            'load': load
+        }
+
+    def _lazy_obj(self):
+        d = self._lasdo
+        if d['loaded']:
+            obj = d['obj']
+        else:
+            obj = d['load']()
+            assert isinstance(obj, dict)
+            d['obj'] = obj
+            d['loaded'] = True
+        return obj
+
+    def __getitem__(self, key):
+        d = self._lazy_obj()
+        return d.__getitem__(key)
+
+    def __setitem__(self, key, value):
+        d = self._lazy_obj()
+        d.__setitem__(key, value)
+
+    def __delitem__(self, key):
+        d = self._lazy_obj()
+        d.__delitem__(key)
+
+    def __iter__(self):
+        for item in self._lazy_obj():
+            yield item
+
+    def __len__(self):
+        return self._lazy_obj().__len__()
+
+    # Implementation of "=="  is needed so that loading doesn't get triggered during the trait
+    # setting when the KernelSpec instance is created.
+    def __eq__(self, other):
+        if self._lasdo['loaded']:
+            return dict(self.items()) == dict(other.items())
+        else:
+            raise ValueError("Real values not yet loaded")

--- a/environment_kernels/utils.py
+++ b/environment_kernels/utils.py
@@ -1,0 +1,71 @@
+# coding: utf-8
+"""Compatibility tricks for Python 3. Mainly to do with unicode."""
+
+# https://github.com/ipython/ipython/blob/master/IPython/utils/py3compat.py
+# Parts of it stolen from IPython under the 3-Clause BSD:
+#
+# =============================
+#  The IPython licensing terms
+# =============================
+#
+# IPython is licensed under the terms of the Modified BSD License (also known as
+# New or Revised or 3-Clause BSD), as follows:
+#
+# - Copyright (c) 2008-2014, IPython Development Team
+# - Copyright (c) 2001-2007, Fernando Perez <fernando.perez@colorado.edu>
+# - Copyright (c) 2001, Janko Hauser <jhauser@zscout.de>
+# - Copyright (c) 2001, Nathaniel Gray <n8gray@caltech.edu>
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# Neither the name of the IPython Development Team nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+import os
+import sys
+import platform
+
+if sys.version_info[0] >= 3:
+    PY3 = True
+    FileNotFoundError = FileNotFoundError
+
+else:
+    PY3 = False
+    FileNotFoundError = IOError
+
+PY2 = not PY3
+
+ON_DARWIN = platform.system() == 'Darwin'
+ON_LINUX = platform.system() == 'Linux'
+ON_WINDOWS = platform.system() == 'Windows'
+
+PYTHON_VERSION_INFO = sys.version_info[:3]
+ON_ANACONDA = any(s in sys.version for s in {'Anaconda', 'Continuum'})
+
+
+ON_POSIX = (os.name == 'posix')
+

--- a/environment_kernels/utils.py
+++ b/environment_kernels/utils.py
@@ -52,10 +52,12 @@ import platform
 if sys.version_info[0] >= 3:
     PY3 = True
     FileNotFoundError = FileNotFoundError
+    from collections.abc import MutableMapping as MutableMapping
 
 else:
     PY3 = False
     FileNotFoundError = IOError
+    from collections import MutableMapping as MutableMapping
 
 PY2 = not PY3
 


### PR DESCRIPTION
This sets the env variable to an proxy dict which only loads the env variables when they are actually used, e.g. during kernel creation (not sure if there is anything earlier, like the UI wanting to get the kernel specs). The result is that the startup now doesn't activates all environments and is therefore much faster. 

This should also fix the py27 problem in https://github.com/Cadair/jupyter_environment_kernels/issues/20#issuecomment-230184551