### PR TITLE
Fix argvquote issue with path including hosts

### DIFF
--- a/environment_kernels/activate_helper.py
+++ b/environment_kernels/activate_helper.py
@@ -136,16 +136,23 @@ def argvquote(arg, force=False):
         n_backslashes = 0
         cmdline = '"'
         for c in arg:
+            if c == "\\":
+                # first count the number of current backslashes
+                n_backslashes += 1
+                continue
             if c == '"':
+                # Escape all backslashes and the following double quotation mark
                 cmdline += (n_backslashes * 2 + 1) * '\\'
             else:
+                # backslashes are not special here
                 cmdline += n_backslashes * '\\'
-            if c != '\\':
-                cmdline += c
-                n_backslashes = 0
-            else:
-                n_backslashes += 1
-        return cmdline + n_backslashes * 2 * '\\' + '"'
+            n_backslashes = 0
+            cmdline += c
+        # Escape all backslashes, but let the terminating
+        # double quotation mark we add below be interpreted
+        # as a metacharacter
+        cmdline += + n_backslashes * 2 * '\\' + '"'
+        return cmdline
 
 
 def escape_windows_cmd_string(s):


### PR DESCRIPTION
The problem was that `\\machine\dir\file.bat` is quoted as
`"\\\machine\dir\path.bat"` leading to unsuccessful commands.

This reimplements the mentioned algorithm from
https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
more closely.

Closes: https://github.com/Cadair/jupyter_environment_kernels/issues/25

xonsh PR in https://github.com/xonsh/xonsh/pull/1882
