### PR TITLE
Rkernel improvements

### DIFF
--- a/environment_kernels/envs_common.py
+++ b/environment_kernels/envs_common.py
@@ -33,9 +33,9 @@ def convert_to_env_data(mgr, env_paths, validator_func, activate_func,
         kernel_name = name_template.format(name_prefix + venv_name)
         kernel_name = kernel_name.lower()
         if kernel_name in env_data:
-            mgr.log.error(
-                "Duplicate env kernels: %s would both point to %s and %s. Using the first!",
-                kernel_name, env_data[kernel_name], venv_dir)
+            mgr.log.debug(
+                "Found duplicate env kernel: %s, which would again point to %s. Using the first!",
+                kernel_name, venv_dir)
             continue
         argv, language, resource_dir = validator_func(venv_dir)
         if not argv:
@@ -52,7 +52,7 @@ def convert_to_env_data(mgr, env_paths, validator_func, activate_func,
         def loader(env_dir=venv_dir, activate_func=activate_func, mgr=mgr):
             mgr.log.debug("Loading env data for %s" % env_dir)
             res = activate_func(mgr, env_dir)
-            #mgr.log.info("PATH: %s" % res['PATH'])
+            # mgr.log.info("PATH: %s" % res['PATH'])
             return res
 
         kspec = EnvironmentLoadingKernelSpec(loader, **kspec_dict)

--- a/environment_kernels/envs_common.py
+++ b/environment_kernels/envs_common.py
@@ -100,19 +100,24 @@ def validate_IRkernel(venv_dir):
     Returns: tuple
         (ARGV, language, resource_dir)
     """
-    r_exe_name = find_exe(venv_dir, "r")
+    r_exe_name = find_exe(venv_dir, "R")
     if r_exe_name is None:
         return [], None, None
 
-    # check if this is really an ipython **kernel**
+    # check if this is really an IRkernel **kernel**
     import subprocess
+    ressources_dir = None
     try:
-        subprocess.check_call([r_exe_name, '--slave', '-e', 'library(IRkernel)'])
+        print_resources = 'cat(as.character(system.file("kernelspec", package = "IRkernel")))'
+        resources_dir_bytes = subprocess.check_output([r_exe_name, '--slave', '-e', print_resources])
+        resources_dir = resources_dir_bytes.decode(errors='ignore')
     except:
         # not installed? -> not useable in any case...
         return [], None, None
     argv = [r_exe_name, "--slave", "-e", "IRkernel::main()", "--args", "{connection_file}"]
-    resources_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logos", "r")
+    if not os.path.exists(resources_dir.strip()):
+        # Fallback to our own log, but don't get the nice js goodies...
+        resources_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logos", "r")
     return argv, "r", resources_dir
 
 

--- a/environment_kernels/envs_conda.py
+++ b/environment_kernels/envs_conda.py
@@ -15,13 +15,14 @@ def get_conda_env_data(mgr):
     if not mgr.find_conda_envs:
         return {}
 
-    mgr.log.info("Looking for conda environments (python)...")
+    mgr.log.debug("Looking for conda environments in %s...", mgr.conda_env_dirs)
 
     # find all potential env paths
     env_paths = find_env_paths_in_basedirs(mgr.conda_env_dirs)
     env_paths.extend(_find_conda_env_paths_from_conda(mgr))
     env_paths = list(set(env_paths)) # remove duplicates
 
+    mgr.log.debug("Scanning conda environments for python kernels...")
     env_data = convert_to_env_data(mgr=mgr,
                                    env_paths=env_paths,
                                    validator_func=validate_IPykernel,
@@ -30,7 +31,7 @@ def get_conda_env_data(mgr):
                                    display_name_template=mgr.display_name_template,
                                    name_prefix="")  # lets keep the py kernels without a prefix...
     if mgr.find_r_envs:
-        mgr.log.info("Looking for conda environments (R)...")
+        mgr.log.debug("Scanning conda environments for R kernels...")
         env_data.update(convert_to_env_data(mgr=mgr,
                                             env_paths=env_paths,
                                             validator_func=validate_IRkernel,
@@ -66,7 +67,7 @@ def _find_conda_env_paths_from_conda(mgr):
     # this is expensive, so make it configureable...
     if not mgr.use_conda_directly:
         return []
-    mgr.log.info("Looking for conda environments by calling conda directly...")
+    mgr.log.debug("Looking for conda environments by calling conda directly...")
     import subprocess
     import json
     try:

--- a/environment_kernels/envs_virtualenv.py
+++ b/environment_kernels/envs_virtualenv.py
@@ -8,6 +8,7 @@ from .utils import ON_WINDOWS
 from .activate_helper import source_env_vars_from_command
 from .envs_common import find_env_paths_in_basedirs, convert_to_env_data, validate_IPykernel
 
+
 def get_virtualenv_env_data(mgr):
     """Finds kernel specs from virtualenv environments
 
@@ -17,11 +18,12 @@ def get_virtualenv_env_data(mgr):
     if not mgr.find_virtualenv_envs:
         return {}
 
-    mgr.log.info("Looking for virtualenv environments...")
+    mgr.log.debug("Looking for virtualenv environments in %s...", mgr.virtualenv_env_dirs)
 
     # find all potential env paths
     env_paths = find_env_paths_in_basedirs(mgr.virtualenv_env_dirs)
 
+    mgr.log.debug("Scanning virtualenv environments for python kernels...")
     env_data = convert_to_env_data(mgr=mgr,
                                    env_paths=env_paths,
                                    validator_func=validate_IPykernel,
@@ -29,7 +31,7 @@ def get_virtualenv_env_data(mgr):
                                    name_template=mgr.conda_prefix_template,
                                    display_name_template=mgr.display_name_template,
                                    name_prefix="")  # virtualenv has only python, so no need for a
-                                                    # prefix
+    # prefix
     return env_data
 
 
@@ -40,7 +42,7 @@ def _get_env_vars_for_virtualenv_env(mgr, env_path):
         args = ['source', os.path.join(env_path, "bin", "activate")]
     try:
         envs = source_env_vars_from_command(args)
-        #mgr.log.debug("Environment variables: %s", envs)
+        # mgr.log.debug("Environment variables: %s", envs)
         return envs
     except:
         # as a fallback, don't activate...


### PR DESCRIPTION
This has two commits:

* a fix for scanning for R kernels (R vs r) and picking up the right ressource dir (there are additional keyboard shortcuts in there!)
* Less log noise: my jupyter notebook server is a systemd service and I don't want to have the complete scan log for environment kernels in the log every 5 minutes...

Tested with conda stuff on linux